### PR TITLE
feat: add URIs to schema

### DIFF
--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,25 @@
+name: Test
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set up Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: ^1.21
+          cache: true
+
+      - name: Run Go Tests
+        run: go test -coverprofile coverage.out ./...

--- a/types/types.go
+++ b/types/types.go
@@ -203,8 +203,17 @@ type Input struct {
 	//   URI allows you to declare the URI the test should use as part of the request line.
 	// examples:
 	//   - name: URI
-	//     value: "\"/get?hello=world\""
+	//     value: '/get?hello=world"
 	URI *string `yaml:"uri,omitempty" json:"uri,omitempty" koanf:"uri,omitempty"`
+
+	// description: |
+	//   URIs is a list of URIs that the test should use as part of the request line.
+	//   If URIs is set, URI will be ignored. URIs is useful for tests that need to send multiple requests.
+	//   Caveat: you cannot change the method or headers between requests.
+	// examples:
+	//   - name: URIs
+	//     value: ['/get?hello=world', '/request/this?var=value']
+	URIs []string `yaml:"uris,omitempty" json:"uris,omitempty" koanf:"uris,omitempty"`
 
 	// description: |
 	//   FollowRedirect will expect the previous stage of the same test to have received a
@@ -336,7 +345,7 @@ type Response struct {
 
 	// description: |
 	//   LogMessage specifies a message to be printed in the log of the backend server that sends the response.
-	//   This can be helpful when debugging, to match resopnses sent by the backend to test executions.
+	//   This can be helpful when debugging, to match responses sent by the backend to test executions.
 	// examples:
 	//   - name: LogMessage
 	//     value: "\"Response splitting test 1\""

--- a/types/types.go
+++ b/types/types.go
@@ -203,12 +203,13 @@ type Input struct {
 	//   URI allows you to declare the URI the test should use as part of the request line.
 	// examples:
 	//   - name: URI
-	//     value: '/get?hello=world"
+	//     value: '/get?hello=world'
 	URI *string `yaml:"uri,omitempty" json:"uri,omitempty" koanf:"uri,omitempty"`
 
 	// description: |
 	//   URIs is a list of URIs that the test should use as part of the request line.
-	//   If URIs is set, URI will be ignored. URIs is useful for tests that need to send multiple requests.
+	//   If URIs is set, URI will be ignored. URIs is useful for running the same test against multiple URIs, e.g., when
+	//   matching on URI paths.
 	//   Caveat: you cannot change the method or headers between requests.
 	// examples:
 	//   - name: URIs

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -33,6 +33,7 @@ tests:
             Accept: "*/*"
           encoded_request: "TXkgRGF0YQo="
           uri: "/test"
+          uris: ["/test", "/multiple", "/uris"]
           protocol: "http"
           autocomplete_headers: false
           stop_magic: true
@@ -84,6 +85,8 @@ var ftwTest = &FTWTest{
 					Input: Input{
 						DestAddr: helpers.StrPtr("127.0.0.1"),
 						Port:     helpers.IntPtr(80),
+						URI:      helpers.StrPtr("/test"),
+						URIs:     []string{"/test", "/multiple", "/uris"},
 						Method:   helpers.StrPtr("OPTIONS"),
 						Headers: map[string]string{
 							"User-Agent": "FTW Schema Tests",
@@ -124,6 +127,8 @@ func TestUnmarshalFTWTest(t *testing.T) {
 			expectedStage := expectedTest.Stages[j]
 			assertions.Equal(expectedStage.Input.DestAddr, stage.Input.DestAddr)
 			assertions.Equal(expectedStage.Input.Port, stage.Input.Port)
+			assertions.Equal(expectedStage.Input.URI, stage.Input.URI)
+			assertions.Equal(expectedStage.Input.URIs, stage.Input.URIs)
 			assertions.Equal(expectedStage.Input.Method, stage.Input.Method)
 			assertions.Len(stage.Input.Headers, len(expectedStage.Input.Headers))
 


### PR DESCRIPTION
## what

- add `URIs` as a new field

## why

- supporting using multiple URIs for testing multiple targets with the same parameters
- https://github.com/coreruleset/go-ftw/issues/256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying multiple request-line URIs in a single test stage, while maintaining backward compatibility with existing single URI configurations.

* **Tests**
  * Implemented automated workflow to run unit tests with coverage reporting on every push and pull request to the main branch.

* **Documentation**
  * Corrected documentation typo for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->